### PR TITLE
feat: add REST file transfer endpoints, list_artifacts/list_src tools…

### DIFF
--- a/agentrun_plus/api/api.py
+++ b/agentrun_plus/api/api.py
@@ -15,6 +15,8 @@ class SessionCreateResponse(BaseModel):
     workdir: str
     source_path: str
     artifact_path: str
+    upload_url: str       # REST endpoint to POST a file into src/ (multipart/form-data, field name: 'file')
+    artifacts_url: str    # Base REST URL for downloading artifacts via GET /<filename>
 
 class ExecuteCodeRequest(BaseModel):
     python_code: str
@@ -45,6 +47,8 @@ class SessionInfo:
     workdir: str
     source_path: str
     artifact_path: str
+    upload_url: str = ""       # REST endpoint to POST a file into src/ (multipart/form-data, field name: 'file')
+    artifacts_url: str = ""    # Base REST URL for downloading artifacts via GET /<filename>
 
 # -------------------------------------
 # Helper Class for REST API Usage.
@@ -189,6 +193,18 @@ class AgentRunAPIClient:
         
         return dest_path
     
+    def list_artifacts(self, session_id: str) -> dict:
+        """List files in a session's artifacts/ directory with download URLs and sizes"""
+        response = self.session.get(self._url(f"/sessions/{session_id}/artifacts"))
+        self._handle_response(response, f"List Artifacts [{session_id}]")
+        return response.json()
+
+    def list_src(self, session_id: str) -> dict:
+        """List files in a session's src/ directory (uploaded input files)"""
+        response = self.session.get(self._url(f"/sessions/{session_id}/src"))
+        self._handle_response(response, f"List Src [{session_id}]")
+        return response.json()
+
     def get_packages(self) -> dict:
         """Get the list of installed Python packages in the runner container"""
         response = self.session.get(self._url("/packages"))

--- a/agentrun_plus/api/mcp_client.py
+++ b/agentrun_plus/api/mcp_client.py
@@ -227,14 +227,17 @@ class AgentRunMCPClient:
         """Create a new AgentRun session
 
         Returns:
-            SessionInfo: Session information with session_id, workdir, paths
+            SessionInfo: Session information with session_id, workdir, paths,
+                         upload_url, and artifacts_url
         """
         result = self._call_tool("create_session")
         return SessionInfo(
             session_id=result["session_id"],
             workdir=result["workdir"],
             source_path=result["source_path"],
-            artifact_path=result["artifact_path"]
+            artifact_path=result["artifact_path"],
+            upload_url=result.get("upload_url", ""),
+            artifacts_url=result.get("artifacts_url", ""),
         )
 
     def get_session_info(self, session_id: str) -> dict:
@@ -339,6 +342,32 @@ class AgentRunMCPClient:
         })
 
         return result
+
+    def list_artifacts(self, session_id: str) -> dict:
+        """List files in a session's artifacts/ directory with download URLs and sizes.
+
+        Args:
+            session_id: The session ID
+
+        Returns:
+            dict: {
+                "artifacts": [{"name": str, "size_bytes": int, "download_url": str}, ...],
+                "count": int,
+                "artifacts_url": str
+            }
+        """
+        return self._call_tool("list_artifacts", {"session_id": session_id})
+
+    def list_src(self, session_id: str) -> dict:
+        """List files in a session's src/ directory (uploaded input files).
+
+        Args:
+            session_id: The session ID
+
+        Returns:
+            dict: {"files": [{"name": str, "size_bytes": int}, ...], "count": int}
+        """
+        return self._call_tool("list_src", {"session_id": session_id})
 
     def download_file(self, session_id: str, src_path: str, dest_path: str,
                      filename: Optional[str] = None) -> str:


### PR DESCRIPTION
…, and curl-friendly download

Large and binary files (images, databases, etc.) previously had to pass through the LLM as base64, bloating the context window. This change adds proper REST endpoints and MCP tools so LLMs can transfer files via curl without routing bytes through the model.

Changes:
- backend.py: add list_artifact_files() and list_src_files() session methods
- api.py: add upload_url/artifacts_url fields to SessionCreateResponse and SessionInfo; add list_artifacts() and list_src() to AgentRunAPIClient
- main.py: add AGENTRUN_BASE_URL env var; add GET /sessions/{id}/artifacts (curl-friendly download with correct 404 handling), GET /sessions/{id}/artifacts (list with download URLs), and GET /sessions/{id}/src (list uploaded files)
- mcp_server.py: expose list_artifacts and list_src as MCP tools; update create_session response with upload_url/artifacts_url; improve upload_file and download_file docstrings with size guidance and curl examples
- mcp_client.py: add list_artifacts() and list_src() methods; populate new URL fields in create_session
- tests: add coverage for all new functionality across backend, REST API, MCP server (legacy client), and AgentRunMCPClient test suites
- .claude/settings.local.json: allow all MCP tools in project permissions