### PR TITLE
feat: add SSE transport endpoint and smoke tests

### DIFF
--- a/agentrun_plus/api/main.py
+++ b/agentrun_plus/api/main.py
@@ -41,7 +41,13 @@ backend = AgentRun(container_url='http://python-runner:5000')
 sessions: Dict[str, AgentRunSession] = {}
 
 # Create MCP app (before lifespan - we need mcp_app.lifespan)
-mcp_app = create_mcp_app(backend, sessions, base_url=AGENTRUN_BASE_URL)
+mcp = create_mcp_app(backend, sessions, base_url=AGENTRUN_BASE_URL)
+
+# Create a streamable HTTP app.
+mcp_http_app = mcp.http_app(path='/')
+
+# Create a SSE app (for IDEs like Cline).
+mcp_sse_app = mcp.http_app(path='/', transport='sse')
 
 # For now, use MCP app's lifespan directly
 # TODO: Combine with API cleanup logic
@@ -49,11 +55,12 @@ mcp_app = create_mcp_app(backend, sessions, base_url=AGENTRUN_BASE_URL)
 app = FastAPI(
     title="AgentRun API",
     version="1.0.0",
-    lifespan=mcp_app.lifespan
+    lifespan=mcp_http_app.lifespan
 )
 
-# Mount MCP app (shares backend and sessions with REST API)
-app.mount("/mcp", mcp_app)
+# Mount both Streamable HTTP and SSE endpoints.
+app.mount("/mcp", mcp_http_app)
+app.mount("/sse", mcp_sse_app)
 
 # Create a logger for app specific messages.
 log = logging.getLogger(__name__)

--- a/agentrun_plus/api/mcp_server.py
+++ b/agentrun_plus/api/mcp_server.py
@@ -737,6 +737,7 @@ def create_mcp_app(backend: AgentRun, sessions: Dict[str, AgentRunSession], base
             log.error(f'[MCP] Failed to list src files for session {session_id}: {e}')
             return {"success": False, "error": f"Failed to list src files: {str(e)}"}
 
-    # Return the ASGI app for mounting
-    # In FastMCP 2.x, use http_app() to get the ASGI application
-    return mcp.http_app(path='/')
+    # Return the FastMCP instance so that thee caller can create multiple
+    # transport apps (streamable HTTP or SSE for programmatic and IDE clients
+    # respectively).
+    return mcp

--- a/tests/test_agentrun_mcp.py
+++ b/tests/test_agentrun_mcp.py
@@ -861,5 +861,88 @@ class TestMCPListSrc:
         assert "not found" in result.get("error", "").lower()
 
 
+class TestSSEEndpoint:
+    """Smoke tests for SSE transport endpoint (/sse).
+
+    These tests verify that the SSE transport is accessible and performs the
+    MCP handshake correctly. They do NOT re-test tool functionality (that is
+    covered by the Streamable HTTP tests above).
+    """
+
+    def test_sse_returns_event_stream(self, docker_services):
+        """GET /sse should respond with text/event-stream content type"""
+        _, api_url = docker_services
+        with requests.get(f"{api_url}/sse", stream=True, timeout=5) as resp:
+            assert resp.status_code == 200
+            assert "text/event-stream" in resp.headers.get("content-type", "")
+
+    def test_sse_sends_endpoint_event(self, docker_services):
+        """SSE stream should immediately deliver an 'endpoint' event with a POST URL"""
+        _, api_url = docker_services
+        with requests.get(f"{api_url}/sse", stream=True, timeout=5) as resp:
+            assert resp.status_code == 200
+
+            event_type = None
+            event_data = None
+            for raw_line in resp.iter_lines(decode_unicode=True):
+                if raw_line.startswith("event:"):
+                    event_type = raw_line.split(":", 1)[1].strip()
+                elif raw_line.startswith("data:"):
+                    event_data = raw_line.split(":", 1)[1].strip()
+                if event_type and event_data:
+                    break
+
+            assert event_type == "endpoint", f"Expected 'endpoint' event, got '{event_type}'"
+            assert event_data, "Endpoint event had no data"
+
+    def test_sse_initialize(self, docker_services):
+        """SSE endpoint should accept MCP initialize and tools/list JSON-RPC requests.
+
+        SSE is a bidirectional protocol: responses arrive on the SSE stream, not in the
+        POST response body. Reading the SSE stream asynchronously from a synchronous test
+        requires threading. Since tool functionality is already validated via the Streamable
+        HTTP tests, this test only verifies that the SSE message endpoint correctly accepts
+        well-formed JSON-RPC POSTs (status 200/202), which is sufficient as a smoke test.
+        """
+        _, api_url = docker_services
+
+        with requests.get(f"{api_url}/sse", stream=True, timeout=10) as sse_resp:
+            assert sse_resp.status_code == 200
+
+            # Parse the endpoint event to get the POST URL
+            endpoint_url = None
+            event_type = None
+            for raw_line in sse_resp.iter_lines(decode_unicode=True):
+                if raw_line.startswith("event:"):
+                    event_type = raw_line.split(":", 1)[1].strip()
+                elif raw_line.startswith("data:") and event_type == "endpoint":
+                    path = raw_line.split(":", 1)[1].strip()
+                    endpoint_url = f"{api_url}{path}" if path.startswith("/") else path
+                    break
+
+            assert endpoint_url, "No endpoint event received from SSE stream"
+
+            # Initialize the MCP session
+            init_resp = requests.post(endpoint_url, json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "sse-test-client", "version": "1.0"},
+                },
+            })
+            assert init_resp.status_code in (200, 202)
+
+            # Request the tool list
+            tools_resp = requests.post(endpoint_url, json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+            })
+            assert tools_resp.status_code in (200, 202)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Returns the raw FastMCP instance from create_mcp_app instead of a pre-baked ASGI app, allowing main.py to create both a Streamable HTTP app (/mcp) and an SSE app (/sse) from the same tool registry. The SSE endpoint enables compatibility with IDEs like Cline that expect the legacy SSE transport.

Adds TestSSEEndpoint smoke tests covering: SSE content-type, endpoint event handshake, and MCP session initialization via the SSE message endpoint.